### PR TITLE
registering picture fill scripts is often too late

### DIFF
--- a/inc/class-picturefill-wp.php
+++ b/inc/class-picturefill-wp.php
@@ -55,7 +55,7 @@ if(!class_exists('Picturefill_WP')){
       add_action('init', array('Picturefill_WP', 'set_wpdb'));
       add_action('init', array($this, 'add_update_hook'));
       add_action('wp_loaded', array($this, 'set_parent_model'));
-      add_action('wp_enqueue_scripts', array($this, 'register_picturefill_scripts'));
+      add_action('init', array($this, 'register_picturefill_scripts')); // no need to register vs enqueue scripts so late
       add_filter('the_content', array($this, 'picturefill_wp_apply_to_html'), apply_filters('picturefill_wp_the_content_filter_priority', 11));
       add_action('picturefill_wp_updated', array('Picturefill_WP', 'picturefill_wp_clear_transients'));
     }


### PR DESCRIPTION
While it's proper to use the wp_enqueue_scripts when calling wp_enqueue_script, it is not a good idea for using it for wp_register_script, which will not do anything unless wp_enqueue_script() is called anyway.

For instance, the way it is written, there is no registration of the picturefill script on admin pages. Also, because of the triggering ordering, it is hairy to enqueue scripts in something that requires a wp_iframe.

Moving the registration further upstream to init where it is available to more code and doesn't require multiple triggers.
