### PR TITLE
Fixes Issue 54

### DIFF
--- a/inc/class-model-image-picturefill-wp.php
+++ b/inc/class-model-image-picturefill-wp.php
@@ -105,7 +105,7 @@ if(!class_exists('Model_Image_Picturefill_WP')){
       }
 
       // @see https://github.com/kylereicks/picturefill.js.wp/issues/54
-      if ( !$attributes['size'] ) {
+      if ( !isset($attributes['size_name']) ) {
         if(preg_match('/(?:(?:^|\s)attachment-)([\w|-]+)/', $attributes['class'], $sizes_match)){
           $attributes['sizes_name'] = $sizes_match[1];
         }

--- a/inc/class-model-image-picturefill-wp.php
+++ b/inc/class-model-image-picturefill-wp.php
@@ -104,6 +104,13 @@ if(!class_exists('Model_Image_Picturefill_WP')){
         $attributes['sizes_name'] = $sizes_match[1];
       }
 
+      // @see https://github.com/kylereicks/picturefill.js.wp/issues/54
+      if ( !$attributes['size'] ) {
+        if(preg_match('/(?:(?:^|\s)attachment-)([\w|-]+)/', $attributes['class'], $sizes_match)){
+          $attributes['sizes_name'] = $sizes_match[1];
+        }
+      }
+
       $this->image_attributes = apply_filters('picturefill_wp_initial_image_attributes', $attributes);
     }
 


### PR DESCRIPTION
Looks like WordPress core has a bug where `get_image_tag()` returns a different class than `wp_get_attachment_image()`. This shouldn't be a filter though, but patched in the plugin itself given the core spits it out.

Note to upstream: Without this patch, post thumbnails might not get properly sized (not sure they'll get properly sized post patch as I don't use this plugin yet). Even if they do get properly sized some parts of the code that are wasteful will get exercised to determine the srcset mappings.
