### PR TITLE
Add cdn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,18 @@ Like many WordPress themes and plugins, Picturefill.WP can be altered and extend
 * `picturefill_wp_image_attribute_{$attribute}`
 * `picturefill_wp_use_explicit_width`
 * `picturefill_wp_output_src`
-* `picturefill_wp_use_cdn`: use true to use 3rd party CDNs for picturefill (default `false`
-* `picturefill_wp_cdn_urlstring`: sprintf URL to 3rd party CDN (default `http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js`)
+* `picturefill_wp_use_cdn`
+* `picturefill_wp_cdn_urlstring`
 
+#### Examples
+
+(e.g. Add these lines to your theme's functions.php.)
+
+##### To prefer loading picturefill.js from cloudflare CDN
+
+```php
+add_filter( 'picturefill_wp_use_cdn', '__return_true' );
+```
 
 Use With Other Plugins
 ----------------------

--- a/README.md
+++ b/README.md
@@ -201,6 +201,8 @@ Like many WordPress themes and plugins, Picturefill.WP can be altered and extend
 * `picturefill_wp_image_attribute_{$attribute}`
 * `picturefill_wp_use_explicit_width`
 * `picturefill_wp_output_src`
+* `picturefill_wp_use_cdn`: use true to use 3rd party CDNs for picturefill (default `false`
+* `picturefill_wp_cdn_urlstring`: sprintf URL to 3rd party CDN (default `http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js`)
 
 
 Use With Other Plugins

--- a/inc/class-picturefill-wp.php
+++ b/inc/class-picturefill-wp.php
@@ -68,11 +68,25 @@ if(!class_exists('Picturefill_WP')){
     }
 
     public function register_picturefill_scripts(){
-      if(WP_DEBUG){
-        wp_register_script('picturefill', PICTUREFILL_WP_URL . 'js/libs/picturefill.js', array(), PICTUREFILL_JS_VERSION, true);
-      }else{
-        wp_register_script('picturefill', PICTUREFILL_WP_URL . 'js/libs/picturefill.min.js', array(), PICTUREFILL_JS_VERSION, true);
+      // For safety, don't use cdn on admin pages (which normally can't happen unless 4d0d3d1 is committed)
+      if ( apply_filters( 'picturefill_use_cdn', false ) && !is_admin() ) {
+        $picturefill_url =  sprintf(
+          apply_filters( 'picturefill_cdn_urlstring', 'http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js' ),
+          ( is_ssl() ) ? 's' : '',
+          PICTUREFILL_JS_VERSION,
+          ( WP_DEBUG ) ? '' : '.min'
+        );
+        $version = null; // no need to append querystring if going to a CDN
+      } else {
+        $picturefill_url = sprintf(
+          '%s/js/libs/picturefill%s.js',
+          PICTUREFILL_WP_URL,
+          ( WP_DEBUG ) ? '' : '.min'
+        );
+        $version = PICTUREFILL_JS_VERSION;
       }
+
+      wp_register_script( 'picturefill', $picturefill_url, array(), $version );
     }
 
     public function picturefill_wp_apply_to_html($html, $cache = null){

--- a/inc/class-picturefill-wp.php
+++ b/inc/class-picturefill-wp.php
@@ -69,9 +69,9 @@ if(!class_exists('Picturefill_WP')){
 
     public function register_picturefill_scripts(){
       // For safety, don't use cdn on admin pages (which normally can't happen unless 4d0d3d1 is committed)
-      if ( apply_filters( 'picturefill_use_cdn', false ) && !is_admin() ) {
+      if ( apply_filters( 'picturefill_wp_use_cdn', false ) && !is_admin() ) {
         $picturefill_url =  sprintf(
-          apply_filters( 'picturefill_cdn_urlstring', 'http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js' ),
+          apply_filters( 'picturefill_wp_cdn_urlstring', 'http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js' ),
           ( is_ssl() ) ? 's' : '',
           PICTUREFILL_JS_VERSION,
           ( WP_DEBUG ) ? '' : '.min'


### PR DESCRIPTION
Allows picturefill javascript to be loaded from CDN. (Will not load by default or on admin pages).

Added two new filters (and updated read me):

`wp_picturefill_use_cdn`: (default `false`) on whether to use a cdn when available
`wp_picturefill_cdn_urlstring`: (default `http%s://cdnjs.cloudflare.com/ajax/libs/picturefill/%s/picturefill%s.js`) which is a url string map to the recommended CDN for picturefill
